### PR TITLE
Fix #2350 Chrome issue

### DIFF
--- a/lib/Adapter.js
+++ b/lib/Adapter.js
@@ -21,6 +21,7 @@ var browser = require('bowser').browser,
 	canRenegotiate = false,
 	oldSpecRTCOfferOptions = false,
 	browserVersion = Number(browser.version) || 0,
+	Browser = { name: browser.name, version: browserVersion },
 	isDesktop = !!(!browser.mobile || !browser.tablet),
 	hasWebRTC = false,
 	virtGlobal, virtNavigator;
@@ -184,6 +185,9 @@ function Adapter(options) {
 			}
 		};
 	}
+
+	// Expose browser
+	Adapter.Browser = Browser;
 
 	// Expose RTCPeerConnection.
 	Adapter.RTCPeerConnection = RTCPeerConnection || throwNonSupported('RTCPeerConnection');

--- a/lib/RTCPeerConnection.js
+++ b/lib/RTCPeerConnection.js
@@ -211,14 +211,15 @@ RTCPeerConnection.prototype.setRemoteDescription = function (description, succes
 	debug('setRemoteDescription()');
 
 	var self = this,
-		DTMFPayload = description.sdp.match(C.REGEXP_SDP_TELEPHONE_EVENT);
+		DTMFPayload;
 
 	/* Remote DTMF payload change makes Chrome fail
 	 * https://code.google.com/p/webrtc/issues/detail?id=2350
 	 * always provide RTCPeerConnection with the initial remote DTMF payload
 	 */
 	if (Adapter.Browser.name === 'Chrome') {
-		if (DTMFPayload.length >= 2) {
+		DTMFPayload = description.sdp.match(C.REGEXP_SDP_TELEPHONE_EVENT);
+		if (DTMFPayload && DTMFPayload.length >= 2) {
 			if (typeof this.DTMFPayload === 'undefined') {
 				this.DTMFPayload = DTMFPayload[1];
 				debug("remote DTMF payload: " + this.DTMFPayload);

--- a/lib/RTCPeerConnection.js
+++ b/lib/RTCPeerConnection.js
@@ -224,9 +224,8 @@ RTCPeerConnection.prototype.setRemoteDescription = function (description, succes
 				this.DTMFPayload = DTMFPayload[1];
 				debug("remote DTMF payload: " + this.DTMFPayload);
 			} else if (this.DTMFPayload !== DTMFPayload[1]) {
-				description.sdp =
-					description.sdp.replace(C.REGEXP_SDP_TELEPHONE_EVENT, "a=rtpmap:" + this.DTMFPayload + " telephone-event$2");
-				debug("remote DTMF payload changed to: " + DTMFPayload[1] + ". Restoring it to: " + this.DTMFPayload);
+				description.sdp = description.sdp.replace(new RegExp('(^m=audio .+?)(\\s' + DTMFPayload[1] + '(\\s|\r\n))(.+)?','im'),'$1 $3');
+				debug("remote DTMF payload changed to: " + DTMFPayload[1] + ". Removed from the format list");
 			}
 		}
 	}

--- a/lib/RTCPeerConnection.js
+++ b/lib/RTCPeerConnection.js
@@ -17,7 +17,8 @@ var merge = require('merge'),
 		REGEXP_FIX_CANDIDATE: new RegExp(/(^a=|\r|\n)/gi),
 		REGEXP_RELAY_CANDIDATE: new RegExp(/ relay /i),
 		REGEXP_SDP_CANDIDATES: new RegExp(/^a=candidate:.*\r\n/igm),
-		REGEXP_SDP_NON_RELAY_CANDIDATES: new RegExp(/^a=candidate:(.(?!relay ))*\r\n/igm)
+		REGEXP_SDP_NON_RELAY_CANDIDATES: new RegExp(/^a=candidate:(.(?!relay ))*\r\n/igm),
+		REGEXP_SDP_TELEPHONE_EVENT: new RegExp(/^a=rtpmap:\s?(\d+)\s+telephone-event(.+)/im)
 	},
 
 	// Internal variables.
@@ -209,7 +210,25 @@ RTCPeerConnection.prototype.setLocalDescription = function (description, success
 RTCPeerConnection.prototype.setRemoteDescription = function (description, successCallback, failureCallback) {
 	debug('setRemoteDescription()');
 
-	var self = this;
+	var self = this,
+		DTMFPayload = description.sdp.match(C.REGEXP_SDP_TELEPHONE_EVENT);
+
+	/* Remote DTMF payload change makes Chrome fail
+	 * https://code.google.com/p/webrtc/issues/detail?id=2350
+	 * always provide RTCPeerConnection with the initial remote DTMF payload
+	 */
+	if (Adapter.Browser.name === 'Chrome') {
+		if (DTMFPayload.length >= 2) {
+			if (typeof this.DTMFPayload === 'undefined') {
+				this.DTMFPayload = DTMFPayload[1];
+				debug("remote DTMF payload: " + this.DTMFPayload);
+			} else if (this.DTMFPayload !== DTMFPayload[1]) {
+				description.sdp =
+					description.sdp.replace(C.REGEXP_SDP_TELEPHONE_EVENT, "a=rtpmap:" + this.DTMFPayload + " telephone-event$2");
+				debug("remote DTMF payload changed to: " + DTMFPayload[1] + ". Restoring it to: " + this.DTMFPayload);
+			}
+		}
+	}
 
 	this.pc.setRemoteDescription(
 		description,


### PR DESCRIPTION
Changing the remote DTMF payload value on re-negotiation makes Chrome fail on
RTCPeerConnection.setLocalDescription()

Ie;

The remote peer negotiates a DTMF payload value of 126:
a=rtpmap:126 telephone-event/8000

The remote peer later re-ngegotiates a DTMF payload value of 101:
a=rtpmap:101 telephone-event/8000

This is a reported issue in Chrome:
https://code.google.com/p/webrtc/issues/detail?id=2350