### PR TITLE
Fix detection of mobile devices

### DIFF
--- a/lib/Adapter.js
+++ b/lib/Adapter.js
@@ -21,7 +21,7 @@ var browser = require('bowser'),
 	canRenegotiate = false,
 	oldSpecRTCOfferOptions = false,
 	browserVersion = Number(browser.version) || 0,
-	isDesktop = !!(!browser.mobile || !browser.tablet),
+	isDesktop = !!(!browser.mobile && !browser.tablet),
 	hasWebRTC = false,
 	virtGlobal, virtNavigator;
 


### PR DESCRIPTION
Only consider a device is a desktop computer iff is not a mobile nor a
tablet.